### PR TITLE
#96: Check which Python interpreter runs CIKit and Ansible before applying the workaround for reading environment config

### DIFF
--- a/docs/_changelog/2018-01-30/README.md
+++ b/docs/_changelog/2018-01-30/README.md
@@ -3,8 +3,10 @@ title: January 30, 2018
 permalink: /changelog/2018-01-30/
 ---
 
-PHP `7.2` and Xdebug `2.6.0` came in sight. Xdebug for PHP `5.6` has been updated to `2.5.4`.
+- PHP `7.2` and Xdebug `2.6.0` came in sight. Xdebug for PHP `5.6` has been updated to `2.5.4`.
+- Fixed weird issue when Python cannot open environment configuration of a project and `vagrant provision` ends in a failure.
 
-## Reference
+## References
 
-[https://github.com/BR0kEN-/cikit/issues/75](https://github.com/BR0kEN-/cikit/issues/75)
+- [https://github.com/BR0kEN-/cikit/issues/75](https://github.com/BR0kEN-/cikit/issues/75)
+- [https://github.com/BR0kEN-/cikit/issues/96](https://github.com/BR0kEN-/cikit/issues/96)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -100,7 +100,7 @@ else:
             #   $(cat $(which "ansible-playbook") | head -n1 | tr -d '#!') -c 'import yaml'
             # Just works.
             with open(ansible_executable) as ansible_executable:
-                python_ansible = ansible_executable.readline().lstrip('#!').rstrip()
+                python_ansible = ansible_executable.readline().lstrip('#!').strip()
 
                 # Do not apply the workaround if an exactly same interpreter is used for
                 # running CIKit and Ansible.

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -100,13 +100,22 @@ else:
             #   $(cat $(which "ansible-playbook") | head -n1 | tr -d '#!') -c 'import yaml'
             # Just works.
             with open(ansible_executable) as ansible_executable:
-                for key, value in json.loads(
-                    functions.call(
-                        ansible_executable.readline().lstrip('#!').rstrip(),
+                python_ansible = ansible_executable.readline().lstrip('#!').rstrip()
+
+                # Do not apply the workaround if an exactly same interpreter is used for
+                # running CIKit and Ansible.
+                if functions.call('which', 'python') == python_ansible:
+                    import yaml
+
+                    ENV_CONFIG = json.dumps(yaml.load(open(ENV_CONFIG)))
+                else:
+                    ENV_CONFIG = functions.call(
+                        python_ansible,
                         '-c',
                         'import yaml, json\nprint json.dumps(yaml.load(open(\'%s\')))' % ENV_CONFIG,
                     )
-                ).iteritems():
+
+                for key, value in json.loads(ENV_CONFIG).iteritems():
                     # Add the value from environment config only if it's not specified as
                     # an option to the command.
                     if key not in args.extra:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -104,7 +104,7 @@ else:
 
                 # Do not apply the workaround if an exactly same interpreter is used for
                 # running CIKit and Ansible.
-                if functions.call('which', 'python') == python_ansible:
+                if functions.call('which', 'python').strip() == python_ansible:
                     import yaml
 
                     ENV_CONFIG = json.dumps(yaml.load(open(ENV_CONFIG)))


### PR DESCRIPTION
https://github.com/BR0kEN-/cikit/issues/96