### PR TITLE
#110:  Try to get rid of Vagrant and VirtualBox in favor of VM-ish Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !lib/
 !cmf/
 !docs/
+!env/
 docs/_site/
 !tests/
 !scripts/

--- a/env/rm.yml
+++ b/env/rm.yml
@@ -1,0 +1,3 @@
+# requires-project-root
+---
+- import_playbook: start.yml __action=rm

--- a/env/start.yml
+++ b/env/start.yml
@@ -14,6 +14,7 @@
     - name: Define the hostname
       set_fact:
         hostname: "{{ site_url.split('//') | last }}"
+        options: ""
         mounts: ""
         ports: ""
 

--- a/env/start.yml
+++ b/env/start.yml
@@ -18,6 +18,8 @@
         ports: ""
 
     - name: Check whether container exists
+      # Calling "docker" also help to detect whether a system has Docker
+      # and is it running.
       shell: "docker ps -qaf name='^/{{ hostname }}'"
       register: container_exists
 

--- a/env/start.yml
+++ b/env/start.yml
@@ -1,0 +1,28 @@
+# requires-project-root
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+
+  vars_files:
+    - "{{ __targetdir__ }}/.cikit/config.yml"
+
+  vars:
+    __action: start
+
+  tasks:
+    - name: Define the hostname
+      set_fact:
+        hostname: "{{ site_url.split('//') | last }}"
+        mounts: ""
+        ports: ""
+
+    - name: Check whether container exists
+      shell: "docker ps -qaf name='^/{{ hostname }}'"
+      register: container_exists
+
+    - include_tasks: tasks/create.yml
+      when: "not container_exists.stdout and 'start' == __action"
+
+    - include_tasks: "tasks/{{ __action }}.yml"
+      when: container_exists.stdout

--- a/env/start.yml
+++ b/env/start.yml
@@ -14,7 +14,6 @@
     - name: Define the hostname
       set_fact:
         hostname: "{{ site_url.split('//') | last }}"
-        options: ""
         mounts: ""
         ports: ""
 

--- a/env/stop.yml
+++ b/env/stop.yml
@@ -1,0 +1,3 @@
+# requires-project-root
+---
+- import_playbook: start.yml __action=stop

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -29,6 +29,7 @@
       -h '{{ hostname }}' \
       -e 'container=docker' \
       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+      -v '{{ __selfdir__ }}':'{{ __selfdir__ }}' \
       --cap-add=SYS_ADMIN \
       --security-opt seccomp=unconfined \
       --name '{{ hostname }}' \
@@ -39,7 +40,7 @@
 
 - name: Install the requirements
   shell: |-
-    docker exec -t {{ hostname }} bash -c 'apt update -y && apt install sudo python-minimal -y'
+    docker exec -t {{ hostname }} bash -c 'apt update -y && apt install sudo wget python-minimal -y'
 
 - name: Print the name of created container
   debug:

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -11,17 +11,6 @@
       {{ ports }} -p {{ item }}
   with_items: "{{ vm.ports }}"
 
-- name: Determine OS family
-  shell: uname
-  register: uname
-
-- name: Define the options
-  set_fact:
-    options: >-
-      --tmpfs /run
-      --tmpfs /run/lock
-  when: "'Darwin' != uname.stdout"
-
 - name: Create the container
   shell: |-
     docker run \
@@ -30,10 +19,11 @@
       -e 'container=docker' \
       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
       -v '{{ __selfdir__ }}/lib':'{{ __selfdir__ }}/lib' \
+      --tmpfs /run \
+      --tmpfs /run/lock \
       --cap-add=SYS_ADMIN \
       --security-opt seccomp=unconfined \
       --name '{{ hostname }}' \
-      {{ options }} \
       {{ mounts }} \
       {{ ports }} \
       solita/ubuntu-systemd

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -1,0 +1,35 @@
+---
+- name: Define the mounts
+  set_fact:
+    mounts: |-
+      {{ mounts }} -v '{{ item.source if item.source[0] == '/' else __targetdir__ + '/' + item.source }}':'{{ item['target' if item.target else 'source'] }}'
+  with_items: "{{ vm.folders }}"
+
+- name: Define the ports
+  set_fact:
+    ports: |-
+      {{ ports }} -p {{ item }}
+  with_items: "{{ vm.ports }}"
+
+- name: Create the container
+  # @todo These options aren't working on macOS.
+  # -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+  # --tmpfs /run \
+  # --tmpfs /run/lock \
+  # --security-opt seccomp=unconfined \
+  shell: |-
+    docker run \
+      -d \
+      -h '{{ hostname }}' \
+      --name '{{ hostname }}' \
+      {{ mounts }} \
+      {{ ports }} \
+      solita/ubuntu-systemd
+
+- name: Install the requirements
+  shell: |-
+    docker exec -t {{ hostname }} bash -c 'apt update -y && apt install sudo dbus python-minimal -y && service dbus restart'
+
+- name: Print the name of created container
+  debug:
+    msg: "The '{{ hostname }}' just have been created."

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -11,17 +11,26 @@
       {{ ports }} -p {{ item }}
   with_items: "{{ vm.ports }}"
 
+- name: Determine OS family
+  shell: uname
+  register: uname
+
+- name: Define the options
+  set_fact:
+    options: >
+      -v /sys/fs/cgroup:/sys/fs/cgroup:ro
+      --tmpfs /run
+      --tmpfs /run/lock
+      --security-opt seccomp=unconfined
+  when: "'Darwin' != uname.stdout"
+
 - name: Create the container
-  # @todo These options aren't working on macOS.
-  # -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-  # --tmpfs /run \
-  # --tmpfs /run/lock \
-  # --security-opt seccomp=unconfined \
   shell: |-
     docker run \
       -d \
       -h '{{ hostname }}' \
       --name '{{ hostname }}' \
+      {{ options }} \
       {{ mounts }} \
       {{ ports }} \
       solita/ubuntu-systemd

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -29,7 +29,7 @@
       -h '{{ hostname }}' \
       -e 'container=docker' \
       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-      -v '{{ __selfdir__ }}':'{{ __selfdir__ }}' \
+      -v '{{ __selfdir__ }}/lib':'{{ __selfdir__ }}/lib' \
       --cap-add=SYS_ADMIN \
       --security-opt seccomp=unconfined \
       --name '{{ hostname }}' \

--- a/env/tasks/create.yml
+++ b/env/tasks/create.yml
@@ -17,11 +17,9 @@
 
 - name: Define the options
   set_fact:
-    options: >
-      -v /sys/fs/cgroup:/sys/fs/cgroup:ro
+    options: >-
       --tmpfs /run
       --tmpfs /run/lock
-      --security-opt seccomp=unconfined
   when: "'Darwin' != uname.stdout"
 
 - name: Create the container
@@ -29,6 +27,10 @@
     docker run \
       -d \
       -h '{{ hostname }}' \
+      -e 'container=docker' \
+      -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+      --cap-add=SYS_ADMIN \
+      --security-opt seccomp=unconfined \
       --name '{{ hostname }}' \
       {{ options }} \
       {{ mounts }} \
@@ -37,7 +39,7 @@
 
 - name: Install the requirements
   shell: |-
-    docker exec -t {{ hostname }} bash -c 'apt update -y && apt install sudo dbus python-minimal -y && service dbus restart'
+    docker exec -t {{ hostname }} bash -c 'apt update -y && apt install sudo python-minimal -y'
 
 - name: Print the name of created container
   debug:

--- a/env/tasks/do.yml
+++ b/env/tasks/do.yml
@@ -1,0 +1,3 @@
+---
+- name: "{{ operation | default(command | capitalize) }} the '{{ hostname }}' container"
+  shell: docker {{ command }} {{ hostname }}

--- a/env/tasks/is-running.yml
+++ b/env/tasks/is-running.yml
@@ -1,0 +1,4 @@
+---
+- name: Check whether container is running
+  shell: "docker inspect -f {% raw %}{{.State.Running}}{% endraw %} {{ hostname }}"
+  register: container_running

--- a/env/tasks/rm.yml
+++ b/env/tasks/rm.yml
@@ -1,0 +1,7 @@
+---
+- include_tasks: stop.yml
+
+- include_tasks: do.yml
+  args:
+    command: rm
+    operation: Remove

--- a/env/tasks/start.yml
+++ b/env/tasks/start.yml
@@ -1,0 +1,5 @@
+---
+- include_tasks: is-running.yml
+
+- include_tasks: do.yml command=start
+  when: not container_running.stdout | bool

--- a/env/tasks/stop.yml
+++ b/env/tasks/stop.yml
@@ -1,0 +1,5 @@
+---
+- include_tasks: is-running.yml
+
+- include_tasks: do.yml command=stop
+  when: container_running.stdout | bool

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -9,6 +9,28 @@ from subprocess import call
 from arguments import args
 from re import search
 
+
+def get_hostname(action_description):
+    # Read the configuration of a project we're currently in.
+    hostname = functions.get_hostname(variables.read_yaml(variables.CONFIG_FILE))
+
+    if '' == hostname:
+        functions.error(
+            (
+                'You are trying to %s the container but its hostname cannot '
+                'be determined. Did you break the "site_url" variable in "%s"?'
+            )
+            %
+            (
+                action_description,
+                variables.CONFIG_FILE,
+            ),
+            200
+        )
+
+    return hostname
+
+
 PARAMS = []
 
 if variables.INSIDE_VM_OR_CI and not variables.INSIDE_PROJECT_DIR:
@@ -23,11 +45,8 @@ if '' == args.playbook:
 
     sys.exit(0)
 elif 'ssh' == args.playbook:
-    # Read the configuration of a project we're currently in.
-    hostname = functions.get_hostname(variables.read_yaml(variables.dirs['cikit'] + '/config.yml'))
-
-    if '' != hostname:
-        sys.exit(call(['docker exec -it %s bash' % hostname], shell=True))
+    # @todo This leaves Python process to wait for "docker exec". Is it ok?
+    sys.exit(call(['docker exec -it %s bash' % get_hostname('login to')], shell=True))
 
 PLAYBOOK = functions.playbooks_find(
     variables.dirs['scripts'] + '/' + args.playbook,
@@ -44,15 +63,12 @@ if 'CIKIT_LIST_TAGS' in os.environ:
 else:
     # The "cikit provision" run without required "--limit" option.
     if args.playbook.endswith('provision') and not args.limit:
-        hostname = functions.get_hostname(variables.read_yaml(variables.dirs['cikit'] + '/config.yml'))
+        # http://blog.oddbit.com/2015/10/13/ansible-20-the-docker-connection-driver
+        args.limit = get_hostname('provision') + ','
 
-        if '' != hostname:
-            # http://blog.oddbit.com/2015/10/13/ansible-20-the-docker-connection-driver
-            args.limit = hostname + ','
-
-            PARAMS.append("-i '%s'" % args.limit)
-            PARAMS.append("-c docker")
-            PARAMS.append("-u root")
+        PARAMS.append("-i '%s'" % args.limit)
+        PARAMS.append("-c docker")
+        PARAMS.append("-u root")
 
     # Duplicate the "limit" option as "extra" because some playbooks may
     # require it and required options are checked within the "extra" only.

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -51,8 +51,8 @@ else:
             args.limit = hostname + ','
 
             PARAMS.append("-i '%s'" % args.limit)
-            PARAMS.append("-c 'docker'")
-            PARAMS.append("-u 'root'")
+            PARAMS.append("-c docker")
+            PARAMS.append("-u root")
 
     # Duplicate the "limit" option as "extra" because some playbooks may
     # require it and required options are checked within the "extra" only.

--- a/lib/variables.py
+++ b/lib/variables.py
@@ -93,3 +93,5 @@ with open(ANSIBLE_EXECUTABLE) as ANSIBLE_EXECUTABLE:
                     return json.loads(result)
 
             return {}
+
+CONFIG_FILE = dirs['cikit'] + '/config.yml'


### PR DESCRIPTION
#110 

All commands must be executed within CIKit project directory, created by the `init` script, e.g.:

```bash
cikit init --project=test_project
cd test_project
```

### Local environment

```bash
cikit env/start
```

#### Provsion the container

```bash
cikit provision
```

#### Login to the container

```bash
cikit ssh
```

#### Stop the container

```bash
cikit env/stop
```

#### Remove the container

```bash
cikit env/rm
```

### Missing features in comparison to Vagrant + VirtualBox approach

- [ ] DNS proxy server that allows accessing container's network by hostname.
- [ ] Storing the answers to provisioner in `environment.yml`.